### PR TITLE
More params blocked

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,6 +35,30 @@ var block_params = [
 		params: [ "from", "account", "campaign", "post_id", "Paid_support", "linkId", "ref", "src" ],
 		host: "www.yahoo.com"
 	},
+		{
+		params: [ "mbid" ],
+		host: "www.wired.com"
+	},
+	{
+		params: [ "utm_term", "bftw", "bffbmain" ],
+		host: "www.buzzfeed.com"
+	},
+	{
+		params: [ "ocid", "ns_mchannel", "ns_source", "ns_campaign", "ns_linkname" ],
+		host: "www.bbc.com"
+	},
+	{
+		params: [ "smid", "smtyp" ],
+		host: "www.nytimes.com"
+	},
+	{
+		params: [ "ito" ],
+		host: "www.dailymail.co.uk"
+	},
+	{
+		params: [ "scid", "adbpl", "adbpr", "adbid" ],
+		host: "*adobe.com"
+	},
 	{
 		params: [ "utm_source", "utm_campaign", "utm_medium", "utm_content" ],
 		host: "*"


### PR DESCRIPTION
More params for wired.com, buzzfeed.com, bbc.com, nytimes.com, dailymail.co.uk and *.adobe.com
#### wired.com

http://www.wired.com/2015/09/apple-liveblog-iphone-apple-tv-news/?mbid=social_twitter
http://www.wired.com/2015/11/making-dna/?mbid=social_fb
#### Buzzfeed

http://www.buzzfeed.com/susancheng/master-of-none-children-of-immigrants-react?bftw&utm_term=.aqsdf6VaaE#.mogDfdLLv
http://www.buzzfeed.com/scottybryan/jenny-is-adele?bffbmain&utm_term=4ld2asgp#4ldsdgp
#### BBC

http://www.bbc.com/earth/story/20151119-ten-incredible-images-of-the-natural-world?ocid=twert
http://www.bbc.com/news/world-europe-34821813?ocid=socialflow_facebook&ns_mchannel=social&ns_campaign=bbcnews&ns_source=facebook
#### New York Times

http://www.nytimes.com/2015/11/21/science/deforestation-may-threaten-majority-of-amazon-tree-species-study-finds.html?smid=tw-nytimesworld&smtyp=cur
#### Adobe

https://blogs.adobe.com/conversations/2015/11/performance-transparency-highest-score-from-cdp.html?scid=social558234286&adbid=66777235685696&adbpl=tw&adbpr=63234611
http://create.adobe.com/2015/11/3/the_force_is_strong_with_orlando_arocena.html?scid=social55234656&adbid=10153362276618871&adbpl=fb&adbpr=30523523473870
#### Daily Mail

http://www.dailymail.co.uk/news/article-3326708/Jihadists-gunmen-launch-grenade-shooting-rampage-hotel-Mali.html?ito=social-twitter_mailonline
